### PR TITLE
Fix comment about permitted params

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -81,7 +81,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    # Ensure that you are permitting the correct parameters that your form is sending
-    params.require(:task).permit(:title, :private) # replace :title and :description with actual task attributes
+    # Only allow the permitted attributes from the form
+    params.require(:task).permit(:title, :private) # permits :title and :private
   end
 end


### PR DESCRIPTION
## Summary
- clarify the `task_params` comment to state the actual permitted attributes

## Testing
- `bundle exec rake test` *(fails: rbenv: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68535dffbee4832ab22d9980ea9f1807