### PR TITLE
Fix extra closing div in task form

### DIFF
--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -24,5 +24,5 @@
     <%= f.submit 'Save', id: 'my-submit-button' %>
   </div>
   <%= button_tag 'Cancel', type: 'button', id: 'cancel-button', class: 'cancel-task-link' %>
-</div>
+
 <% end %>


### PR DESCRIPTION
## Summary
- remove stray closing `div` from tasks form

## Testing
- `bin/rails test` *(fails: rbenv: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68535df069a0832ab4150ddc1b412ca3