### PR TITLE
Fix typo in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -10,7 +10,7 @@ end
 
 FileUtils.chdir APP_ROOT do
   # This script is a way to set up or update your development environment automatically.
-  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
+  # This script is idempotent, so that you can run it at any time and get an expected outcome.
   # Add necessary setup steps to this file.
 
   puts "== Installing dependencies =="


### PR DESCRIPTION
## Summary
- fix typo in `bin/setup` idempotency comment

## Testing
- `bin/rails test` *(fails: rbenv version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68535de8c5e4832a8a57e58f7cee3305